### PR TITLE
Update PHPStan dependencies to v2 and fix errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "php-stubs/wordpress-tests-stubs": "^6.5",
 		"phpcompatibility/phpcompatibility-wp": "^2.0",
 		"phpstan/extension-installer": "^1.3",
-		"phpstan/phpstan-mockery": "^1.1",
-		"phpstan/phpstan-phpunit": "^1.4",
+		"phpstan/phpstan-mockery": "^2.0",
+		"phpstan/phpstan-phpunit": "^2.0",
         "roave/security-advisories": "dev-master",
-        "szepeviktor/phpstan-wordpress": "^1.3",
+        "szepeviktor/phpstan-wordpress": "^2.0",
         "wp-coding-standards/wpcs": "^3",
         "wp-media/phpunit": "^3"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,6 +25,9 @@
 
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 	</rule>
     <rule ref="WordPress.Files.FileName">
         <properties>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,6 @@ includes:
 parameters:
     level: 9
     inferPrivatePropertyTypeFromConstructor: true
-    reportUnmatchedIgnoredErrors: false
     paths:
         - src/
         - tests/

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -7,8 +7,18 @@ use ReflectionObject;
 use WPMedia\PHPUnit\Integration\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
+	/**
+	 * Configuration for the test data.
+	 *
+	 * @var array{'test_data'?: array<string, mixed>}
+	 */
 	protected $config;
 
+	/**
+	 * Setup method for the test case.
+	 *
+	 * @return void
+	 */
 	public function set_up() {
 		parent::set_up();
 
@@ -17,7 +27,12 @@ abstract class TestCase extends BaseTestCase {
 		}
 	}
 
-	public function configTestData() {
+	/**
+	 * Get the test data configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function configTestData(): array {
 		if ( empty( $this->config ) ) {
 			$this->loadTestDataConfig();
 		}
@@ -27,9 +42,18 @@ abstract class TestCase extends BaseTestCase {
 			: $this->config;
 	}
 
-	protected function loadTestDataConfig() {
+	/**
+	 * Load test data configuration.
+	 *
+	 * @return void
+	 */
+	protected function loadTestDataConfig(): void {
 		$obj      = new ReflectionObject( $this );
 		$filename = $obj->getFileName();
+
+		if ( false === $filename ) {
+			return;
+		}
 
 		$this->config = $this->getTestData( dirname( $filename ), basename( $filename, '.php' ) );
 	}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -7,8 +7,18 @@ use ReflectionObject;
 use WPMedia\PHPUnit\Unit\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase {
+	/**
+	 * Configuration for the test data.
+	 *
+	 * @var array{'test_data'?: array<string, mixed>}
+	 */
 	protected $config;
 
+	/**
+	 * Setup method for the test case.
+	 *
+	 * @return void
+	 */
 	protected function set_up() {
 		parent::set_up();
 
@@ -17,7 +27,12 @@ abstract class TestCase extends BaseTestCase {
 		}
 	}
 
-	public function configTestData() {
+	/**
+	 * Get the test data configuration.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function configTestData(): array {
 		if ( empty( $this->config ) ) {
 			$this->loadTestDataConfig();
 		}
@@ -27,9 +42,18 @@ abstract class TestCase extends BaseTestCase {
 			: $this->config;
 	}
 
-	protected function loadTestDataConfig() {
+	/**
+	 * Load test data configuration.
+	 *
+	 * @return void
+	 */
+	protected function loadTestDataConfig(): void {
 		$obj      = new ReflectionObject( $this );
 		$filename = $obj->getFileName();
+
+		if ( false === $filename ) {
+			return;
+		}
 
 		$this->config = $this->getTestData( dirname( $filename ), basename( $filename, '.php' ) );
 	}


### PR DESCRIPTION
# Description

Update PHPStan & dependencies to v2. Fix errors reported by PHPStan & PHPCS in the tests files

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

n/a

### How to test

n/a

## Technical description

### Documentation

Nothing more than in description

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable for this PR
