### PR TITLE
Add Optin management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
             "WPMedia\\Mixpanel\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "WPMedia\\Mixpanel\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "phpcs": "vendor/bin/phpcs",
         "phpcs:ci": "vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,6 +25,8 @@
 
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 	</rule>
     <rule ref="WordPress.Files.FileName">
         <properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,7 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
     <rule ref="WordPress.Files.FileName">
         <properties>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,4 @@ parameters:
     bootstrapFiles:
     scanFiles:
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+        - vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php

--- a/src/Optin.php
+++ b/src/Optin.php
@@ -54,13 +54,7 @@ class Optin {
 	 * @return void
 	 */
 	public function enable(): void {
-		if ( ! current_user_can( $this->capability ) ) {
-			return;
-		}
-
-		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
-
-		if ( $optin ) {
+		if ( $this->is_enabled() ) {
 			return;
 		}
 
@@ -73,13 +67,7 @@ class Optin {
 	 * @return void
 	 */
 	public function disable(): void {
-		if ( ! current_user_can( $this->capability ) ) {
-			return;
-		}
-
-		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
-
-		if ( ! $optin ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 

--- a/src/Optin.php
+++ b/src/Optin.php
@@ -39,7 +39,7 @@ class Optin {
 			return false;
 		}
 
-		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+		$optin = get_option( $this->plugin_slug . '_mixpanel_optin', false );
 
 		if ( ! $optin ) {
 			return false;

--- a/src/Optin.php
+++ b/src/Optin.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace WPMedia\Mixpanel;
+
+class Optin {
+    /**
+     * The plugin slug.
+     *
+     * @var string
+     */
+    private $plugin_slug;
+
+    /**
+     * The capability required to enable/disable the opt-in.
+     *
+     * @var string
+     */
+    private $capability;
+
+    /**
+     * Constructor.
+     *
+     * @param string $plugin_slug The plugin slug.
+     * @param string $capability  The capability required to enable/disable the opt-in.
+     */
+    public function __construct( string $plugin_slug, string $capability ) {
+        $this->plugin_slug = $plugin_slug;
+        $this->capability  = $capability;
+    }
+
+    /**
+     * Check if the opt-in is enabled.
+     *
+     * @return bool True if the opt-in is enabled, false otherwise.
+     */
+    public function is_enabled(): bool {
+        if ( ! current_user_can( $this->capability ) ) {
+            return false;
+        }
+
+        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+
+        if ( ! $optin ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Enable the opt-in.
+     *
+     * @return void
+     */
+    public function enable(): void {
+        if ( ! current_user_can( $this->capability ) ) {
+            return;
+        }
+
+        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+
+        if ( $optin ) {
+            return;
+        }
+
+        update_option( $this->plugin_slug . '_mixpanel_optin', true );
+    }
+
+    /**
+     * Disable the opt-in.
+     *
+     * @return void
+     */
+    public function disable(): void {
+        if ( ! current_user_can( $this->capability ) ) {
+            return;
+        }
+
+        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+
+        if ( ! $optin ) {
+            return;
+        }
+
+        delete_option( $this->plugin_slug . '_mixpanel_optin' );
+    }
+}

--- a/src/Optin.php
+++ b/src/Optin.php
@@ -4,85 +4,85 @@ declare(strict_types=1);
 namespace WPMedia\Mixpanel;
 
 class Optin {
-    /**
-     * The plugin slug.
-     *
-     * @var string
-     */
-    private $plugin_slug;
+	/**
+	 * The plugin slug.
+	 *
+	 * @var string
+	 */
+	private $plugin_slug;
 
-    /**
-     * The capability required to enable/disable the opt-in.
-     *
-     * @var string
-     */
-    private $capability;
+	/**
+	 * The capability required to enable/disable the opt-in.
+	 *
+	 * @var string
+	 */
+	private $capability;
 
-    /**
-     * Constructor.
-     *
-     * @param string $plugin_slug The plugin slug.
-     * @param string $capability  The capability required to enable/disable the opt-in.
-     */
-    public function __construct( string $plugin_slug, string $capability ) {
-        $this->plugin_slug = $plugin_slug;
-        $this->capability  = $capability;
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @param string $plugin_slug The plugin slug.
+	 * @param string $capability  The capability required to enable/disable the opt-in.
+	 */
+	public function __construct( string $plugin_slug, string $capability ) {
+		$this->plugin_slug = $plugin_slug;
+		$this->capability  = $capability;
+	}
 
-    /**
-     * Check if the opt-in is enabled.
-     *
-     * @return bool True if the opt-in is enabled, false otherwise.
-     */
-    public function is_enabled(): bool {
-        if ( ! current_user_can( $this->capability ) ) {
-            return false;
-        }
+	/**
+	 * Check if the opt-in is enabled.
+	 *
+	 * @return bool True if the opt-in is enabled, false otherwise.
+	 */
+	public function is_enabled(): bool {
+		if ( ! current_user_can( $this->capability ) ) {
+			return false;
+		}
 
-        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
 
-        if ( ! $optin ) {
-            return false;
-        }
+		if ( ! $optin ) {
+			return false;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Enable the opt-in.
-     *
-     * @return void
-     */
-    public function enable(): void {
-        if ( ! current_user_can( $this->capability ) ) {
-            return;
-        }
+	/**
+	 * Enable the opt-in.
+	 *
+	 * @return void
+	 */
+	public function enable(): void {
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
 
-        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
 
-        if ( $optin ) {
-            return;
-        }
+		if ( $optin ) {
+			return;
+		}
 
-        update_option( $this->plugin_slug . '_mixpanel_optin', true );
-    }
+		update_option( $this->plugin_slug . '_mixpanel_optin', true );
+	}
 
-    /**
-     * Disable the opt-in.
-     *
-     * @return void
-     */
-    public function disable(): void {
-        if ( ! current_user_can( $this->capability ) ) {
-            return;
-        }
+	/**
+	 * Disable the opt-in.
+	 *
+	 * @return void
+	 */
+	public function disable(): void {
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
 
-        $optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
+		$optin = get_option( $this->plugin_slug . '_mixpanel_optin' );
 
-        if ( ! $optin ) {
-            return;
-        }
+		if ( ! $optin ) {
+			return;
+		}
 
-        delete_option( $this->plugin_slug . '_mixpanel_optin' );
-    }
+		delete_option( $this->plugin_slug . '_mixpanel_optin' );
+	}
 }

--- a/tests/Fixtures/Optin/DisableTest.php
+++ b/tests/Fixtures/Optin/DisableTest.php
@@ -2,18 +2,18 @@
 
 return [
 	'testShouldDoNothingWhenUserDoesNotHaveCapability' => [
-		'user_role' => 'subscriber',
+		'user_role'    => 'subscriber',
 		'option_value' => true,
-		'expected' => true,
+		'expected'     => true,
 	],
-	'testShouldDoNothingWhenOptinAlreadyDisabled' => [
-		'user_role' => 'administrator',
+	'testShouldDoNothingWhenOptinAlreadyDisabled'      => [
+		'user_role'    => 'administrator',
 		'option_value' => false,
-		'expected' => false,
+		'expected'     => false,
 	],
-	'testShouldDisableOptin' => [
-		'user_role' => 'administrator',
+	'testShouldDisableOptin'                           => [
+		'user_role'    => 'administrator',
 		'option_value' => true,
-		'expected' => false,
+		'expected'     => false,
 	],
 ];

--- a/tests/Fixtures/Optin/DisableTest.php
+++ b/tests/Fixtures/Optin/DisableTest.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenUserDoesNotHaveCapability' => [
+		'user_role' => 'subscriber',
+		'option_value' => true,
+		'expected' => true,
+	],
+	'testShouldDoNothingWhenOptinAlreadyDisabled' => [
+		'user_role' => 'administrator',
+		'option_value' => false,
+		'expected' => false,
+	],
+	'testShouldDisableOptin' => [
+		'user_role' => 'administrator',
+		'option_value' => true,
+		'expected' => false,
+	],
+];

--- a/tests/Fixtures/Optin/EnableTest.php
+++ b/tests/Fixtures/Optin/EnableTest.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+	'testShouldDoNothingWhenUserDoesNotHaveCapability' => [
+		'user_role' => 'subscriber',
+		'option_value' => true,
+		'expected' => true,
+	],
+	'testShouldDoNothingWhenOptinAlreadyEnabled' => [
+		'user_role' => 'administrator',
+		'option_value' => true,
+		'expected' => true,
+	],
+	'testShouldEnableOptin' => [
+		'user_role' => 'administrator',
+		'option_value' => false,
+		'expected' => true,
+	],
+];

--- a/tests/Fixtures/Optin/EnableTest.php
+++ b/tests/Fixtures/Optin/EnableTest.php
@@ -2,18 +2,18 @@
 
 return [
 	'testShouldDoNothingWhenUserDoesNotHaveCapability' => [
-		'user_role' => 'subscriber',
+		'user_role'    => 'subscriber',
 		'option_value' => true,
-		'expected' => true,
+		'expected'     => true,
 	],
-	'testShouldDoNothingWhenOptinAlreadyEnabled' => [
-		'user_role' => 'administrator',
+	'testShouldDoNothingWhenOptinAlreadyEnabled'       => [
+		'user_role'    => 'administrator',
 		'option_value' => true,
-		'expected' => true,
+		'expected'     => true,
 	],
-	'testShouldEnableOptin' => [
-		'user_role' => 'administrator',
+	'testShouldEnableOptin'                            => [
+		'user_role'    => 'administrator',
 		'option_value' => false,
-		'expected' => true,
+		'expected'     => true,
 	],
 ];

--- a/tests/Fixtures/Optin/IsEnabledTest.php
+++ b/tests/Fixtures/Optin/IsEnabledTest.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+	'testShouldReturnFalseWhenUserDoesNotHaveCapability' => [
+		'user_role' => 'subscriber',
+		'option_value' => true,
+		'expected' => false,
+	],
+	'testShouldReturnFalseWhenOptionIsNotSet' => [
+		'user_role' => 'administrator',
+		'option_value' => false,
+		'expected' => false,
+	],
+	'testShouldReturnTrueWhenUserHasCapabilityAndOptionIsSet' => [
+		'user_role' => 'administrator',
+		'option_value' => true,
+		'expected' => true,
+	],
+	'testShouldReturnFalseWhenUserHasCapabilityAndOptionIsNotSet' => [
+		'user_role' => 'administrator',
+		'option_value' => false,
+		'expected' => false,
+	],
+];

--- a/tests/Fixtures/Optin/IsEnabledTest.php
+++ b/tests/Fixtures/Optin/IsEnabledTest.php
@@ -2,23 +2,23 @@
 
 return [
 	'testShouldReturnFalseWhenUserDoesNotHaveCapability' => [
-		'user_role' => 'subscriber',
+		'user_role'    => 'subscriber',
 		'option_value' => true,
-		'expected' => false,
+		'expected'     => false,
 	],
-	'testShouldReturnFalseWhenOptionIsNotSet' => [
-		'user_role' => 'administrator',
+	'testShouldReturnFalseWhenOptionIsNotSet'            => [
+		'user_role'    => 'administrator',
 		'option_value' => false,
-		'expected' => false,
+		'expected'     => false,
 	],
 	'testShouldReturnTrueWhenUserHasCapabilityAndOptionIsSet' => [
-		'user_role' => 'administrator',
+		'user_role'    => 'administrator',
 		'option_value' => true,
-		'expected' => true,
+		'expected'     => true,
 	],
 	'testShouldReturnFalseWhenUserHasCapabilityAndOptionIsNotSet' => [
-		'user_role' => 'administrator',
+		'user_role'    => 'administrator',
 		'option_value' => false,
-		'expected' => false,
+		'expected'     => false,
 	],
 ];

--- a/tests/Integration/Optin/DisableTest.php
+++ b/tests/Integration/Optin/DisableTest.php
@@ -7,14 +7,28 @@ use WPMedia\Mixpanel\Optin;
 use WPMedia\Mixpanel\Tests\Integration\TestCase;
 
 /**
+ * Test the Optin::disable method
+ *
  * @covers WPMedia\Mixpanel\Optin::disable
  */
 class DisableTest extends TestCase {
 	/**
+	 * Test method
+	 *
 	 * @dataProvider configTestData
+	 *
+	 * @param string $user_role    The user role to test.
+	 * @param bool   $option_value The option value to test.
+	 * @param bool   $expected     The expected result.
+	 *
+	 * @return void
 	 */
-	public function testShouldEnableOptin( $user_role, $option_value, $expected ) {
+	public function testShouldEnableOptin( $user_role, $option_value, $expected ): void {
 		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		if ( $user instanceof \WP_Error ) {
+			$this->fail( 'Failed to create user' );
+		}
 
 		wp_set_current_user( $user );
 

--- a/tests/Integration/Optin/DisableTest.php
+++ b/tests/Integration/Optin/DisableTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace WPMedia\Mixpanel\Tests\Integration\Optin;
+
+use WPMedia\Mixpanel\Optin;
+use WPMedia\Mixpanel\Tests\Integration\TestCase;
+
+/**
+ * @covers WPMedia\Mixpanel\Optin::disable
+ */
+class DisableTest extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldEnableOptin( $user_role, $option_value, $expected ) {
+		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		wp_set_current_user( $user );
+
+		update_option( 'mixpanel_mixpanel_optin', $option_value );
+
+		$optin = new Optin( 'mixpanel', 'manage_options' );
+
+		$optin->disable();
+
+		$this->assertSame( $expected, get_option( 'mixpanel_mixpanel_optin' ) );
+	}
+}

--- a/tests/Integration/Optin/EnableTest.php
+++ b/tests/Integration/Optin/EnableTest.php
@@ -7,14 +7,28 @@ use WPMedia\Mixpanel\Optin;
 use WPMedia\Mixpanel\Tests\Integration\TestCase;
 
 /**
+ * Test the Optin::enable method.
+ *
  * @covers WPMedia\Mixpanel\Optin::enable
  */
 class EnableTest extends TestCase {
 	/**
+	 * Test method
+	 *
 	 * @dataProvider configTestData
+	 *
+	 * @param string $user_role    The user role to test.
+	 * @param bool   $option_value The option value to test.
+	 * @param bool   $expected     The expected result.
+	 *
+	 * @return void
 	 */
-	public function testShouldDoExpected( $user_role, $option_value, $expected ) {
+	public function testShouldDoExpected( $user_role, $option_value, $expected ): void {
 		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		if ( $user instanceof \WP_Error ) {
+			$this->fail( 'Failed to create user' );
+		}
 
 		wp_set_current_user( $user );
 

--- a/tests/Integration/Optin/EnableTest.php
+++ b/tests/Integration/Optin/EnableTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace WPMedia\Mixpanel\Tests\Integration\Optin;
+
+use WPMedia\Mixpanel\Optin;
+use WPMedia\Mixpanel\Tests\Integration\TestCase;
+
+/**
+ * @covers WPMedia\Mixpanel\Optin::enable
+ */
+class EnableTest extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldDoExpected( $user_role, $option_value, $expected ) {
+		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		wp_set_current_user( $user );
+
+		update_option( 'mixpanel_mixpanel_optin', $option_value );
+
+		$this->assertSame( $option_value, get_option( 'mixpanel_mixpanel_optin' ) );
+
+		$optin = new Optin( 'mixpanel', 'manage_options' );
+
+		$optin->enable();
+
+		$this->assertSame( $expected, get_option( 'mixpanel_mixpanel_optin' ) );
+	}
+}

--- a/tests/Integration/Optin/IsEnabledTest.php
+++ b/tests/Integration/Optin/IsEnabledTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace WPMedia\Mixpanel\Tests\Integration\Optin;
+
+use WPMedia\Mixpanel\Optin;
+use WPMedia\Mixpanel\Tests\Integration\TestCase;
+
+/**
+ * @covers WPMedia\Mixpanel\Optin::is_enabled
+ */
+class IsEnabledTest extends TestCase {
+	/**
+	 * @dataProvider configTestData
+	 */
+	public function testShouldReturnExpected( $user_role, $option_value, $expected ) {
+		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		wp_set_current_user( $user );
+
+		update_option( 'mixpanel_mixpanel_optin', $option_value );
+
+		$optin = new Optin( 'mixpanel', 'manage_options' );
+
+		$this->assertSame( $expected, $optin->is_enabled() );
+	}
+}

--- a/tests/Integration/Optin/IsEnabledTest.php
+++ b/tests/Integration/Optin/IsEnabledTest.php
@@ -7,14 +7,28 @@ use WPMedia\Mixpanel\Optin;
 use WPMedia\Mixpanel\Tests\Integration\TestCase;
 
 /**
+ * Test the Optin::is_enabled method.
+ *
  * @covers WPMedia\Mixpanel\Optin::is_enabled
  */
 class IsEnabledTest extends TestCase {
 	/**
+	 * Test method
+	 *
 	 * @dataProvider configTestData
+	 *
+	 * @param string $user_role    The user role to test.
+	 * @param bool   $option_value The option value to test.
+	 * @param bool   $expected     The expected result.
+	 *
+	 * @return void
 	 */
-	public function testShouldReturnExpected( $user_role, $option_value, $expected ) {
+	public function testShouldReturnExpected( $user_role, $option_value, $expected ): void {
 		$user = self::factory()->user->create( [ 'role' => $user_role ] );
+
+		if ( $user instanceof \WP_Error ) {
+			$this->fail( 'Failed to create user' );
+		}
 
 		wp_set_current_user( $user );
 


### PR DESCRIPTION
# Description

Add Optin management class, with methods to enable, disable, and check current optin option value

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## Detailed scenario

### What was tested

Automated testing of all methods with integration tests

### How to test

n/a

## Technical description

### Documentation

The `Optin` class expects a plugin slug and a capability to check against. The slug is used as the prefix for the option name.

To enable/disable the optin, A user needs to have the appropriate capability.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.