### PR TITLE
Closes #25 Add debug activation and logging for events

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -178,6 +178,10 @@ class Tracking {
 		$all_plugins    = get_plugins();
 
 		foreach ( $active_plugins as $plugin_path ) {
+			if ( ! is_string( $plugin_path ) ) {
+				continue;
+			}
+
 			if ( ! isset( $all_plugins[ $plugin_path ] ) ) {
 				continue;
 			}


### PR DESCRIPTION
# Description

Fixes #25

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

N/A

### How to test

- Enable `WP_DEBUG` and `WP_DEBUG_LOG`
- Trigger Mixpanel events
- Event name and properties should show in the log file

## Technical description

### Documentation

This PR adds debug functionality to the Mixpanel tracking system, allowing developers to log events to WordPress debug logs when debug mode is enabled. The implementation provides a way to monitor Mixpanel events during development and debugging.

- Adds debug mode detection based on WordPress debug constants
- Implements event logging functionality with filter support
- Integrates logging into the existing track method

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests added