### PR TITLE
Adds a way to bypass

### DIFF
--- a/src/TrackingPlugin.php
+++ b/src/TrackingPlugin.php
@@ -101,6 +101,18 @@ class TrackingPlugin extends Tracking {
 
 		$properties = array_merge( $properties, $defaults );
 
+		$this->track_event_with_parent( $event, $properties );
+	}
+
+	/**
+	 * Tracks an event by calling the parent track method with a capitalized event name.
+	 *
+	 * @param string $event      The name of the event to be tracked.
+	 * @param array  $properties The properties associated with the event.
+	 *
+	 * @return void
+	 */
+	protected function track_event_with_parent( string $event, array $properties ): void {
 		parent::track( ucfirst( $event ), $properties );
 	}
 

--- a/src/TrackingPlugin.php
+++ b/src/TrackingPlugin.php
@@ -54,7 +54,15 @@ class TrackingPlugin extends Tracking {
 	 * @param string  $event      Event name.
 	 * @param mixed[] $properties Event properties.
 	 * @param string  $event_capability The capability required to track the event.
-	 * @param bool    $bypass_capability Whether to bypass capability check.
+	 * @param bool    $bypass_capability If true, bypasses capability checks. Use only when you have ensured proper authorization elsewhere.
+	 *
+	 * When should this parameter be used:
+	 *   - Only in trusted contexts where user authorization has already been verified.
+	 * Security implications:
+	 *   - Bypassing capability checks may allow unauthorized users to track events.
+	 * Responsibility:
+	 *   - The caller is responsible for ensuring proper authorization when this is set to true.
+	 * @security This parameter is security-sensitive. Improper use may lead to privilege escalation or unauthorized event tracking.
 	 */
 	public function track( string $event, array $properties, string $event_capability = '', bool $bypass_capability = false ): void {
 		/**

--- a/src/TrackingPlugin.php
+++ b/src/TrackingPlugin.php
@@ -54,36 +54,39 @@ class TrackingPlugin extends Tracking {
 	 * @param string  $event      Event name.
 	 * @param mixed[] $properties Event properties.
 	 * @param string  $event_capability The capability required to track the event.
-	 * @param bool    $bypass_capability If true, bypasses capability checks. Use only when you have ensured proper authorization elsewhere.
 	 *
-	 * When should this parameter be used:
-	 *   - Only in trusted contexts where user authorization has already been verified.
-	 * Security implications:
-	 *   - Bypassing capability checks may allow unauthorized users to track events.
-	 * Responsibility:
-	 *   - The caller is responsible for ensuring proper authorization when this is set to true.
-	 * @security This parameter is security-sensitive. Improper use may lead to privilege escalation or unauthorized event tracking.
+	 * @return void
 	 */
-	public function track( string $event, array $properties, string $event_capability = '', bool $bypass_capability = false ): void {
-		if ( ! $bypass_capability ) {
-			/**
-			 * Filter the default capability required to track a specific event.
-			 *
-			 * @param string $capability The capability required to track the event.
-			 * @param string $event      The event name.
-			 * @param string $app        The application name.
-			 */
-			$default = apply_filters( 'wp_mixpanel_event_capability', 'manage_options', $event, $this->app );
+	public function track( string $event, array $properties, string $event_capability = '' ): void {
+		/**
+		 * Filter the default capability required to track a specific event.
+		 *
+		 * @param string $capability The capability required to track the event.
+		 * @param string $event      The event name.
+		 * @param string $app        The application name.
+		 */
+		$default = apply_filters( 'wp_mixpanel_event_capability', 'manage_options', $event, $this->app );
 
-			if ( empty( $event_capability ) ) {
-				$event_capability = $default;
-			}
-
-			if ( ! current_user_can( $event_capability ) ) {
-				return;
-			}
+		if ( empty( $event_capability ) ) {
+			$event_capability = $default;
 		}
 
+		if ( ! current_user_can( $event_capability ) ) {
+			return;
+		}
+
+		$this->track_direct( $event, $properties );
+	}
+
+	/**
+	 * Track an event directly in Mixpanel, bypassing capability checks.
+	 *
+	 * @param string  $event      Event name.
+	 * @param mixed[] $properties Event properties.
+	 *
+	 * @return void
+	 */
+	public function track_direct( string $event, array $properties ): void {
 		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
 
 		if ( ! $host ) {
@@ -101,18 +104,6 @@ class TrackingPlugin extends Tracking {
 
 		$properties = array_merge( $properties, $defaults );
 
-		$this->track_event_with_parent( $event, $properties );
-	}
-
-	/**
-	 * Tracks an event by calling the parent track method with a capitalized event name.
-	 *
-	 * @param string $event      The name of the event to be tracked.
-	 * @param array  $properties The properties associated with the event.
-	 *
-	 * @return void
-	 */
-	protected function track_event_with_parent( string $event, array $properties ): void {
 		parent::track( ucfirst( $event ), $properties );
 	}
 

--- a/src/TrackingPlugin.php
+++ b/src/TrackingPlugin.php
@@ -54,8 +54,9 @@ class TrackingPlugin extends Tracking {
 	 * @param string  $event      Event name.
 	 * @param mixed[] $properties Event properties.
 	 * @param string  $event_capability The capability required to track the event.
+	 * @param bool    $bypass_capability Whether to bypass capability check.
 	 */
-	public function track( string $event, array $properties, string $event_capability = '' ): void {
+	public function track( string $event, array $properties, string $event_capability = '', bool $bypass_capability = false ): void {
 		/**
 		 * Filter the default capability required to track a specific event.
 		 *
@@ -69,7 +70,7 @@ class TrackingPlugin extends Tracking {
 			$event_capability = $default;
 		}
 
-		if ( ! current_user_can( $event_capability ) ) {
+		if ( ! $bypass_capability && ! current_user_can( $event_capability ) ) {
 			return;
 		}
 

--- a/src/TrackingPlugin.php
+++ b/src/TrackingPlugin.php
@@ -65,21 +65,23 @@ class TrackingPlugin extends Tracking {
 	 * @security This parameter is security-sensitive. Improper use may lead to privilege escalation or unauthorized event tracking.
 	 */
 	public function track( string $event, array $properties, string $event_capability = '', bool $bypass_capability = false ): void {
-		/**
-		 * Filter the default capability required to track a specific event.
-		 *
-		 * @param string $capability The capability required to track the event.
-		 * @param string $event      The event name.
-		 * @param string $app        The application name.
-		 */
-		$default = apply_filters( 'wp_mixpanel_event_capability', 'manage_options', $event, $this->app );
+		if ( ! $bypass_capability ) {
+			/**
+			 * Filter the default capability required to track a specific event.
+			 *
+			 * @param string $capability The capability required to track the event.
+			 * @param string $event      The event name.
+			 * @param string $app        The application name.
+			 */
+			$default = apply_filters( 'wp_mixpanel_event_capability', 'manage_options', $event, $this->app );
 
-		if ( empty( $event_capability ) ) {
-			$event_capability = $default;
-		}
+			if ( empty( $event_capability ) ) {
+				$event_capability = $default;
+			}
 
-		if ( ! $bypass_capability && ! current_user_can( $event_capability ) ) {
-			return;
+			if ( ! current_user_can( $event_capability ) ) {
+				return;
+			}
 		}
 
 		$host = wp_parse_url( get_home_url(), PHP_URL_HOST );

--- a/tests/Fixtures/TrackingPlugin/TrackTest.php
+++ b/tests/Fixtures/TrackingPlugin/TrackTest.php
@@ -7,6 +7,7 @@ return [
 			'capability'       => 'manage_options',
 			'user_can'         => false,
 			'event_capability' => '',
+			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'manage_options',
@@ -18,6 +19,7 @@ return [
 			'capability'       => 'edit_posts',
 			'user_can'         => false,
 			'event_capability' => '',
+			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
@@ -29,9 +31,16 @@ return [
 			'capability'       => 'manage_options',
 			'user_can'         => false,
 			'event_capability' => 'edit_posts',
+			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
 		],
+	],
+	'testShouldBypassCapabilityCheckWithBypassSetToTrue' => [
+		'config'   => [
+			'bypass_capability' => true,
+		],
+		'expected' => [],
 	],
 ];

--- a/tests/Fixtures/TrackingPlugin/TrackTest.php
+++ b/tests/Fixtures/TrackingPlugin/TrackTest.php
@@ -7,7 +7,6 @@ return [
 			'capability'        => 'manage_options',
 			'user_can'          => false,
 			'event_capability'  => '',
-			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'manage_options',
@@ -19,7 +18,6 @@ return [
 			'capability'        => 'edit_posts',
 			'user_can'          => false,
 			'event_capability'  => '',
-			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
@@ -31,27 +29,9 @@ return [
 			'capability'        => 'manage_options',
 			'user_can'          => false,
 			'event_capability'  => 'edit_posts',
-			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
-		],
-	],
-	'testShouldBypassCapabilityCheckWithBypassSetToTrue'   => [
-		'config'   => [
-			'event_capability'  => '',
-			'bypass_capability' => true,
-		],
-		'expected' => [
-			'properties' => [
-				'key'         => 'value',
-				'domain'      => '',
-				'wp_version'  => '',
-				'php_version' => '',
-				'plugin'      => 'test_plugin',
-				'brand'       => 'test_brand',
-				'application' => 'test_app',
-			],
 		],
 	],
 ];

--- a/tests/Fixtures/TrackingPlugin/TrackTest.php
+++ b/tests/Fixtures/TrackingPlugin/TrackTest.php
@@ -39,8 +39,19 @@ return [
 	],
 	'testShouldBypassCapabilityCheckWithBypassSetToTrue'   => [
 		'config'   => [
+			'event_capability'  => '',
 			'bypass_capability' => true,
 		],
-		'expected' => [],
+		'expected' => [
+			'properties' => [
+				'key'         => 'value',
+				'domain'      => '',
+				'wp_version'  => '',
+				'php_version' => '',
+				'plugin'      => 'test_plugin',
+				'brand'       => 'test_brand',
+				'application' => 'test_app',
+			],
+		],
 	],
 ];

--- a/tests/Fixtures/TrackingPlugin/TrackTest.php
+++ b/tests/Fixtures/TrackingPlugin/TrackTest.php
@@ -3,10 +3,10 @@
 return [
 	'testShouldDoNothingIfNoCapability'                    => [
 		'config'   => [
-			'filter_value'      => null,
-			'capability'        => 'manage_options',
-			'user_can'          => false,
-			'event_capability'  => '',
+			'filter_value'     => null,
+			'capability'       => 'manage_options',
+			'user_can'         => false,
+			'event_capability' => '',
 		],
 		'expected' => [
 			'capability' => 'manage_options',
@@ -14,10 +14,10 @@ return [
 	],
 	'testShouldDoNothingIfNoCapabilityWithFilter'          => [
 		'config'   => [
-			'filter_value'      => 'edit_posts',
-			'capability'        => 'edit_posts',
-			'user_can'          => false,
-			'event_capability'  => '',
+			'filter_value'     => 'edit_posts',
+			'capability'       => 'edit_posts',
+			'user_can'         => false,
+			'event_capability' => '',
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
@@ -25,10 +25,10 @@ return [
 	],
 	'testShouldDoNothingIfNoCapabilityWithEventCapability' => [
 		'config'   => [
-			'filter_value'      => null,
-			'capability'        => 'manage_options',
-			'user_can'          => false,
-			'event_capability'  => 'edit_posts',
+			'filter_value'     => null,
+			'capability'       => 'manage_options',
+			'user_can'         => false,
+			'event_capability' => 'edit_posts',
 		],
 		'expected' => [
 			'capability' => 'edit_posts',

--- a/tests/Fixtures/TrackingPlugin/TrackTest.php
+++ b/tests/Fixtures/TrackingPlugin/TrackTest.php
@@ -3,10 +3,10 @@
 return [
 	'testShouldDoNothingIfNoCapability'                    => [
 		'config'   => [
-			'filter_value'     => null,
-			'capability'       => 'manage_options',
-			'user_can'         => false,
-			'event_capability' => '',
+			'filter_value'      => null,
+			'capability'        => 'manage_options',
+			'user_can'          => false,
+			'event_capability'  => '',
 			'bypass_capability' => false,
 		],
 		'expected' => [
@@ -15,10 +15,10 @@ return [
 	],
 	'testShouldDoNothingIfNoCapabilityWithFilter'          => [
 		'config'   => [
-			'filter_value'     => 'edit_posts',
-			'capability'       => 'edit_posts',
-			'user_can'         => false,
-			'event_capability' => '',
+			'filter_value'      => 'edit_posts',
+			'capability'        => 'edit_posts',
+			'user_can'          => false,
+			'event_capability'  => '',
 			'bypass_capability' => false,
 		],
 		'expected' => [
@@ -27,17 +27,17 @@ return [
 	],
 	'testShouldDoNothingIfNoCapabilityWithEventCapability' => [
 		'config'   => [
-			'filter_value'     => null,
-			'capability'       => 'manage_options',
-			'user_can'         => false,
-			'event_capability' => 'edit_posts',
+			'filter_value'      => null,
+			'capability'        => 'manage_options',
+			'user_can'          => false,
+			'event_capability'  => 'edit_posts',
 			'bypass_capability' => false,
 		],
 		'expected' => [
 			'capability' => 'edit_posts',
 		],
 	],
-	'testShouldBypassCapabilityCheckWithBypassSetToTrue' => [
+	'testShouldBypassCapabilityCheckWithBypassSetToTrue'   => [
 		'config'   => [
 			'bypass_capability' => true,
 		],

--- a/tests/Unit/TrackingPlugin/TrackTest.php
+++ b/tests/Unit/TrackingPlugin/TrackTest.php
@@ -44,6 +44,16 @@ class TrackTest extends TestCase {
 	 * @return void
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
+		if ( $config['bypass_capability'] ) {
+			Filters\expectApplied( 'wp_mixpanel_event_capability' )
+				->never();
+
+			Functions\expect( 'current_user_can' )
+				->never();
+			
+			return;
+		}
+
 		if ( $config['filter_value'] ) {
 			Filters\expectApplied( 'wp_mixpanel_event_capability' )
 				->once()
@@ -55,6 +65,6 @@ class TrackTest extends TestCase {
 			->with( $expected['capability'] )
 			->andReturn( $config['user_can'] );
 
-		$this->tracking_plugin->track( 'event_name', [ 'key' => 'value' ], $config['event_capability'] );
+		$this->tracking_plugin->track( 'event_name', [ 'key' => 'value' ], $config['event_capability'], $config['bypass_capability'] );
 	}
 }

--- a/tests/Unit/TrackingPlugin/TrackTest.php
+++ b/tests/Unit/TrackingPlugin/TrackTest.php
@@ -50,7 +50,7 @@ class TrackTest extends TestCase {
 
 			Functions\expect( 'current_user_can' )
 				->never();
-			
+
 			return;
 		}
 

--- a/tests/Unit/TrackingPlugin/TrackTest.php
+++ b/tests/Unit/TrackingPlugin/TrackTest.php
@@ -30,7 +30,10 @@ class TrackTest extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->tracking_plugin = new TrackingPlugin( 'test_token', 'test_plugin', 'test_brand', 'test_app' );
+		$this->tracking_plugin = $this->getMockBuilder( TrackingPlugin::class )
+			->setConstructorArgs( [ 'test_token', 'test_plugin', 'test_brand', 'test_app' ] )
+			->onlyMethods( [ 'track_event_with_parent', 'hash', 'get_wp_version', 'get_php_version' ] )
+			->getMock();
 	}
 
 	/**
@@ -51,19 +54,32 @@ class TrackTest extends TestCase {
 			Functions\expect( 'current_user_can' )
 				->never();
 
-			return;
-		}
-
-		if ( $config['filter_value'] ) {
-			Filters\expectApplied( 'wp_mixpanel_event_capability' )
+			Functions\expect( 'wp_parse_url' )
 				->once()
-				->andReturn( $config['filter_value'] );
-		}
+				->andReturn( 'example.org' );
 
-		Functions\expect( 'current_user_can' )
-			->once()
-			->with( $expected['capability'] )
-			->andReturn( $config['user_can'] );
+			Functions\expect( 'get_home_url' )
+				->once()
+				->andReturn( 'example.org' );
+
+			$this->tracking_plugin->expects( $this->once() )
+				->method( 'track_event_with_parent' )
+				->with(
+					'event_name',
+					$expected['properties']
+				);
+		} else {
+			if ( $config['filter_value'] ) {
+				Filters\expectApplied( 'wp_mixpanel_event_capability' )
+					->once()
+					->andReturn( $config['filter_value'] );
+			}
+
+			Functions\expect( 'current_user_can' )
+				->once()
+				->with( $expected['capability'] )
+				->andReturn( $config['user_can'] );
+		}
 
 		$this->tracking_plugin->track( 'event_name', [ 'key' => 'value' ], $config['event_capability'], $config['bypass_capability'] );
 	}

--- a/tests/Unit/TrackingPlugin/TrackTest.php
+++ b/tests/Unit/TrackingPlugin/TrackTest.php
@@ -30,10 +30,7 @@ class TrackTest extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->tracking_plugin = $this->getMockBuilder( TrackingPlugin::class )
-			->setConstructorArgs( [ 'test_token', 'test_plugin', 'test_brand', 'test_app' ] )
-			->onlyMethods( [ 'track_event_with_parent', 'hash', 'get_wp_version', 'get_php_version' ] )
-			->getMock();
+		$this->tracking_plugin = new TrackingPlugin( 'test_token', 'test_plugin', 'test_brand', 'test_app' );
 	}
 
 	/**
@@ -47,40 +44,18 @@ class TrackTest extends TestCase {
 	 * @return void
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
-		if ( $config['bypass_capability'] ) {
+
+		if ( $config['filter_value'] ) {
 			Filters\expectApplied( 'wp_mixpanel_event_capability' )
-				->never();
-
-			Functions\expect( 'current_user_can' )
-				->never();
-
-			Functions\expect( 'wp_parse_url' )
 				->once()
-				->andReturn( 'example.org' );
-
-			Functions\expect( 'get_home_url' )
-				->once()
-				->andReturn( 'example.org' );
-
-			$this->tracking_plugin->expects( $this->once() )
-				->method( 'track_event_with_parent' )
-				->with(
-					'event_name',
-					$expected['properties']
-				);
-		} else {
-			if ( $config['filter_value'] ) {
-				Filters\expectApplied( 'wp_mixpanel_event_capability' )
-					->once()
-					->andReturn( $config['filter_value'] );
-			}
-
-			Functions\expect( 'current_user_can' )
-				->once()
-				->with( $expected['capability'] )
-				->andReturn( $config['user_can'] );
+				->andReturn( $config['filter_value'] );
 		}
 
-		$this->tracking_plugin->track( 'event_name', [ 'key' => 'value' ], $config['event_capability'], $config['bypass_capability'] );
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( $expected['capability'] )
+			->andReturn( $config['user_can'] );
+
+		$this->tracking_plugin->track( 'event_name', [ 'key' => 'value' ], $config['event_capability'] );
 	}
 }


### PR DESCRIPTION
# Description

Fixes #x
Adds a way to bypass the `current_user_can()` check before sending tracking event. 
Useful in a CRON context. where we are not runing the code with an admin user.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Sending events from a CRON context in WP rocket

### How to test

All process of WP Rocket - Rocket Inisghts

## Technical description

### Documentation

This pull request introduces a small but important change to the `TrackingPlugin` class to allow bypassing the capability check when tracking events. This provides more flexibility for tracking events under different conditions.

* Tracking logic update: Added a `bypass_capability` boolean parameter to the `track` method in `TrackingPlugin`, which allows callers to skip the user capability check when tracking an event. [[1]](diffhunk://#diff-878786cff3a224904cc94f28e314c398800e349e51f9fe0a9d19a3e6cb7063afR57-R59) [[2]](diffhunk://#diff-878786cff3a224904cc94f28e314c398800e349e51f9fe0a9d19a3e6cb7063afL72-R73)

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Difficult to tick everything to be honest 