### PR TITLE
Closes #33 Send analytics requests non-blocking with a 1s timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ The filter can takes 3 arguments:
 - `$event` the current event name
 - `$app` the current app name
 
+## Request behaviour
+
+Events are sent with `wp_remote_post()` when the in-memory queue is flushed. Because analytics must never delay a response, requests are **non-blocking** and use a **1 second timeout** by default.
+
+Two filters control this, both receiving the target host as their second argument:
+
+- `wp_media_mixpanel_request_timeout` — the timeout in seconds. Non-numeric values fall back to the default.
+- `wp_media_mixpanel_request_blocking` — whether the request waits for a response.
+
+```php
+add_filter( 'wp_media_mixpanel_request_timeout', function( $timeout, $host ) {
+	return 2;
+}, 10, 2 );
+```
+
+Two things are worth knowing before changing these:
+
+- **1 second is a floor, not a default.** WordPress clamps the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver uses `alarm()`, which only has second resolution. Passing a smaller value has no effect on the request.
+- **Non-blocking is not fire-and-forget.** WordPress still waits for the endpoint up to the timeout; it only skips reading and parsing the response. The timeout is what bounds the cost of a degraded endpoint.
+
+A failed request is reported through the consumer's error callback and then **dropped**. It is not retried, because the producer's retry-on-flush behaviour would multiply the cost of an unreachable endpoint across every request.
+
 # Read more about MixPanel at group.one
 
 More information about how MixPanel is used at group.one is available in [our internal documentation](https://group-one.atlassian.net/wiki/spaces/PA1/folder/33940931155?atlOrigin=eyJpIjoiZGNhYmI5MDMyZmZiNGY4MmIzOWZkNDNmZmY3ZjcyNDAiLCJwIjoiYyJ9). 

--- a/README.md
+++ b/README.md
@@ -103,16 +103,14 @@ The filter can takes 3 arguments:
 
 ## Request behaviour
 
-Events are sent with `wp_remote_post()` when the in-memory queue is flushed. Because analytics must never delay a response, requests are **non-blocking** and use a **1 second timeout**.
-
-Neither value is filterable or configurable — analytics is not important enough to be allowed to slow down a site, so there is no supported way to raise them.
+Events are sent with `wp_remote_post()` when the in-memory queue is flushed. Requests are **non-blocking** with a **1 second timeout**, and neither value is filterable or configurable: analytics must never delay a response.
 
 Two details are worth knowing:
 
-- **1 second is a floor, not a choice.** WordPress clamps the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver uses `alarm()`, which only has second resolution. A smaller value would have no effect on the request.
-- **Non-blocking is not fire-and-forget.** WordPress still waits for the endpoint up to the timeout; it only skips reading and parsing the response. The timeout is what bounds the cost of a degraded endpoint.
+- **1 second is a floor, not a choice.** WordPress clamps the cURL timeout to a minimum of 1 second, so a smaller value would have no effect.
+- **Non-blocking is not fire-and-forget.** WordPress still waits for the endpoint up to the timeout, it only discards the response. The timeout is what bounds the cost of a degraded endpoint.
 
-A failed request is reported through the consumer's error callback and then **dropped**. It is not retried, because the producer's retry-on-flush behaviour would multiply the cost of an unreachable endpoint across every request.
+A failed request is reported through the consumer's error callback and then **dropped**, not retried, because the producer's retry-on-flush behaviour would multiply the cost of an unreachable endpoint.
 
 # Read more about MixPanel at group.one
 

--- a/README.md
+++ b/README.md
@@ -103,22 +103,13 @@ The filter can takes 3 arguments:
 
 ## Request behaviour
 
-Events are sent with `wp_remote_post()` when the in-memory queue is flushed. Because analytics must never delay a response, requests are **non-blocking** and use a **1 second timeout** by default.
+Events are sent with `wp_remote_post()` when the in-memory queue is flushed. Because analytics must never delay a response, requests are **non-blocking** and use a **1 second timeout**.
 
-Two filters control this, both receiving the target host as their second argument:
+Neither value is filterable or configurable — analytics is not important enough to be allowed to slow down a site, so there is no supported way to raise them.
 
-- `wp_media_mixpanel_request_timeout` — the timeout in seconds. Non-numeric values fall back to the default.
-- `wp_media_mixpanel_request_blocking` — whether the request waits for a response.
+Two details are worth knowing:
 
-```php
-add_filter( 'wp_media_mixpanel_request_timeout', function( $timeout, $host ) {
-	return 2;
-}, 10, 2 );
-```
-
-Two things are worth knowing before changing these:
-
-- **1 second is a floor, not a default.** WordPress clamps the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver uses `alarm()`, which only has second resolution. Passing a smaller value has no effect on the request.
+- **1 second is a floor, not a choice.** WordPress clamps the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver uses `alarm()`, which only has second resolution. A smaller value would have no effect on the request.
 - **Non-blocking is not fire-and-forget.** WordPress still waits for the endpoint up to the timeout; it only skips reading and parsing the response. The timeout is what bounds the cost of a degraded endpoint.
 
 A failed request is reported through the consumer's error callback and then **dropped**. It is not retried, because the producer's retry-on-flush behaviour would multiply the cost of an unreachable endpoint across every request.

--- a/src/WPConsumer.php
+++ b/src/WPConsumer.php
@@ -11,16 +11,17 @@ use WPMedia_ConsumerStrategies_AbstractConsumer;
 class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 
 	/**
-	 * Default number of seconds to allow the request to execute.
+	 * Number of seconds to allow the request to execute.
 	 *
-	 * This is also the lowest value WordPress can honour: Requests clamps the cURL
-	 * timeout to a minimum of 1 second, because cURL's system DNS resolver uses
-	 * alarm(), which only has second resolution. Passing a smaller value has no
+	 * Analytics must never delay a response, so this is deliberately not
+	 * configurable. It is also the lowest value WordPress can honour: Requests clamps
+	 * the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver
+	 * uses alarm(), which only has second resolution. A smaller value would have no
 	 * effect on the actual request.
 	 *
 	 * @var int
 	 */
-	const DEFAULT_TIMEOUT = 1;
+	const REQUEST_TIMEOUT = 1;
 
 	/**
 	 * The host to connect to (e.g. api.mixpanel.com)
@@ -37,20 +38,6 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	protected $endpoint;
 
 	/**
-	 * The maximum number of seconds to allow the call to execute.
-	 *
-	 * @var int|float
-	 */
-	protected $timeout;
-
-	/**
-	 * Whether the request waits for a response.
-	 *
-	 * @var bool
-	 */
-	protected $blocking;
-
-	/**
 	 * The protocol to use for the cURL connection
 	 *
 	 * @var string
@@ -60,63 +47,17 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	/**
 	 * Creates a new WPConsumer and assigns properties from the $options array
 	 *
-	 * @param array{host:string, endpoint:string, timeout?: int|float, blocking?: bool, use_ssl?: bool} $options Options for the consumer.
+	 * The timeout and blocking behaviour of the request is fixed and cannot be set
+	 * through the options.
+	 *
+	 * @param array{host: string, endpoint: string, use_ssl?: bool} $options Options for the consumer.
 	 */
 	public function __construct( $options ) {
 		parent::__construct( $options );
 
 		$this->host     = $options['host'];
 		$this->endpoint = $options['endpoint'];
-		$this->timeout  = isset( $options['timeout'] ) ? $options['timeout'] : self::DEFAULT_TIMEOUT;
-		$this->blocking = isset( $options['blocking'] ) ? (bool) $options['blocking'] : false;
 		$this->protocol = isset( $options['use_ssl'] ) && ( true === $options['use_ssl'] ) ? 'https' : 'http';
-	}
-
-	/**
-	 * Get the timeout, in seconds, to use for the request
-	 *
-	 * @return int|float
-	 */
-	protected function get_timeout() {
-		/**
-		 * Filters the timeout, in seconds, for analytics requests.
-		 *
-		 * Values below 1 have no effect: WordPress clamps the cURL timeout to a minimum
-		 * of 1 second. Keep this value low, analytics must never delay a response.
-		 *
-		 * @param mixed  $timeout Request timeout in seconds, as an int or a float.
-		 *                        Non-numeric values fall back to self::DEFAULT_TIMEOUT.
-		 * @param string $host    Host the request is sent to.
-		 */
-		$timeout = apply_filters( 'wp_media_mixpanel_request_timeout', $this->timeout, $this->host );
-
-		if ( is_int( $timeout ) || is_float( $timeout ) ) {
-			return $timeout;
-		}
-
-		if ( is_numeric( $timeout ) ) {
-			return (float) $timeout;
-		}
-
-		return self::DEFAULT_TIMEOUT;
-	}
-
-	/**
-	 * Check whether the request should wait for a response
-	 *
-	 * @return bool
-	 */
-	protected function is_blocking(): bool {
-		/**
-		 * Filters whether analytics requests wait for a response.
-		 *
-		 * Note that a non-blocking request is not fire-and-forget: WordPress still waits
-		 * for the endpoint up to the timeout, it only discards the response.
-		 *
-		 * @param bool   $blocking Whether the request waits for a response.
-		 * @param string $host     Host the request is sent to.
-		 */
-		return (bool) apply_filters( 'wp_media_mixpanel_request_blocking', $this->blocking, $this->host );
 	}
 
 	/**
@@ -134,11 +75,16 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 		$url  = $this->protocol . '://' . $this->host . $this->endpoint;
 		$data = 'data=' . $this->_encode( $batch );
 
+		/*
+		 * Note that a non-blocking request is not fire-and-forget: WordPress still waits
+		 * for the endpoint up to the timeout, it only skips reading and parsing the
+		 * response. The timeout is what bounds the cost of a degraded endpoint.
+		 */
 		$response = wp_remote_post(
 			$url,
 			[
-				'timeout'  => $this->get_timeout(),
-				'blocking' => $this->is_blocking(),
+				'timeout'  => self::REQUEST_TIMEOUT,
+				'blocking' => false,
 				'body'     => $data,
 			]
 		);

--- a/src/WPConsumer.php
+++ b/src/WPConsumer.php
@@ -11,6 +11,18 @@ use WPMedia_ConsumerStrategies_AbstractConsumer;
 class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 
 	/**
+	 * Default number of seconds to allow the request to execute.
+	 *
+	 * This is also the lowest value WordPress can honour: Requests clamps the cURL
+	 * timeout to a minimum of 1 second, because cURL's system DNS resolver uses
+	 * alarm(), which only has second resolution. Passing a smaller value has no
+	 * effect on the actual request.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_TIMEOUT = 1;
+
+	/**
 	 * The host to connect to (e.g. api.mixpanel.com)
 	 *
 	 * @var string
@@ -25,11 +37,18 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	protected $endpoint;
 
 	/**
-	 * The maximum number of seconds to allow the call to execute. Default is 30 seconds.
+	 * The maximum number of seconds to allow the call to execute.
 	 *
-	 * @var int
+	 * @var int|float
 	 */
 	protected $timeout;
+
+	/**
+	 * Whether the request waits for a response.
+	 *
+	 * @var bool
+	 */
+	protected $blocking;
 
 	/**
 	 * The protocol to use for the cURL connection
@@ -41,15 +60,63 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	/**
 	 * Creates a new WPConsumer and assigns properties from the $options array
 	 *
-	 * @param array{host:string, endpoint:string, timeout?: int, use_ssl?: bool} $options Options for the consumer.
+	 * @param array{host:string, endpoint:string, timeout?: int|float, blocking?: bool, use_ssl?: bool} $options Options for the consumer.
 	 */
 	public function __construct( $options ) {
 		parent::__construct( $options );
 
 		$this->host     = $options['host'];
 		$this->endpoint = $options['endpoint'];
-		$this->timeout  = isset( $options['timeout'] ) ? $options['timeout'] : 30;
+		$this->timeout  = isset( $options['timeout'] ) ? $options['timeout'] : self::DEFAULT_TIMEOUT;
+		$this->blocking = isset( $options['blocking'] ) ? (bool) $options['blocking'] : false;
 		$this->protocol = isset( $options['use_ssl'] ) && ( true === $options['use_ssl'] ) ? 'https' : 'http';
+	}
+
+	/**
+	 * Get the timeout, in seconds, to use for the request
+	 *
+	 * @return int|float
+	 */
+	protected function get_timeout() {
+		/**
+		 * Filters the timeout, in seconds, for analytics requests.
+		 *
+		 * Values below 1 have no effect: WordPress clamps the cURL timeout to a minimum
+		 * of 1 second. Keep this value low, analytics must never delay a response.
+		 *
+		 * @param mixed  $timeout Request timeout in seconds, as an int or a float.
+		 *                        Non-numeric values fall back to self::DEFAULT_TIMEOUT.
+		 * @param string $host    Host the request is sent to.
+		 */
+		$timeout = apply_filters( 'wp_media_mixpanel_request_timeout', $this->timeout, $this->host );
+
+		if ( is_int( $timeout ) || is_float( $timeout ) ) {
+			return $timeout;
+		}
+
+		if ( is_numeric( $timeout ) ) {
+			return (float) $timeout;
+		}
+
+		return self::DEFAULT_TIMEOUT;
+	}
+
+	/**
+	 * Check whether the request should wait for a response
+	 *
+	 * @return bool
+	 */
+	protected function is_blocking(): bool {
+		/**
+		 * Filters whether analytics requests wait for a response.
+		 *
+		 * Note that a non-blocking request is not fire-and-forget: WordPress still waits
+		 * for the endpoint up to the timeout, it only discards the response.
+		 *
+		 * @param bool   $blocking Whether the request waits for a response.
+		 * @param string $host     Host the request is sent to.
+		 */
+		return (bool) apply_filters( 'wp_media_mixpanel_request_blocking', $this->blocking, $this->host );
 	}
 
 	/**
@@ -70,16 +137,30 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 		$response = wp_remote_post(
 			$url,
 			[
-				'timeout' => $this->timeout,
-				'body'    => $data,
+				'timeout'  => $this->get_timeout(),
+				'blocking' => $this->is_blocking(),
+				'body'     => $data,
 			]
 		);
 
 		if ( is_wp_error( $response ) ) {
 			$this->_handleError( $response->get_error_code(), $response->get_error_message() );
-			return false;
 		}
 
+		/*
+		 * Always report the batch as consumed, even when the request failed.
+		 *
+		 * Analytics is non-essential, and returning false here is expensive: the producer
+		 * puts the batch back on the queue and retries the flush up to 10 times from its
+		 * destructor, once per producer. An unreachable endpoint would then cost up to
+		 * 10 timeouts for each of the events, people and groups producers, at PHP
+		 * shutdown, while the visitor is still waiting for the response.
+		 *
+		 * Dropping the batch keeps a degraded endpoint bounded to a single timeout.
+		 * Failures are still reported through _handleError().
+		 *
+		 * @see \WPMedia_Producers_MixpanelBaseProducer::__destruct()
+		 */
 		return true;
 	}
 }

--- a/src/WPConsumer.php
+++ b/src/WPConsumer.php
@@ -13,11 +13,8 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	/**
 	 * Number of seconds to allow the request to execute.
 	 *
-	 * Analytics must never delay a response, so this is deliberately not
-	 * configurable. It is also the lowest value WordPress can honour: Requests clamps
-	 * the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver
-	 * uses alarm(), which only has second resolution. A smaller value would have no
-	 * effect on the actual request.
+	 * Not configurable: analytics must never delay a response. Also the lowest value
+	 * WordPress honours, as it clamps the cURL timeout to a minimum of 1 second.
 	 *
 	 * @var int
 	 */
@@ -47,8 +44,7 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 	/**
 	 * Creates a new WPConsumer and assigns properties from the $options array
 	 *
-	 * The timeout and blocking behaviour of the request is fixed and cannot be set
-	 * through the options.
+	 * The request timeout and blocking behaviour are fixed, and cannot be set here.
 	 *
 	 * @param array{host: string, endpoint: string, use_ssl?: bool} $options Options for the consumer.
 	 */
@@ -75,11 +71,8 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 		$url  = $this->protocol . '://' . $this->host . $this->endpoint;
 		$data = 'data=' . $this->_encode( $batch );
 
-		/*
-		 * Note that a non-blocking request is not fire-and-forget: WordPress still waits
-		 * for the endpoint up to the timeout, it only skips reading and parsing the
-		 * response. The timeout is what bounds the cost of a degraded endpoint.
-		 */
+		// Non-blocking still waits up to the timeout, it only discards the response:
+		// the timeout is what bounds the cost of a degraded endpoint.
 		$response = wp_remote_post(
 			$url,
 			[
@@ -94,16 +87,9 @@ class WPConsumer extends WPMedia_ConsumerStrategies_AbstractConsumer {
 		}
 
 		/*
-		 * Always report the batch as consumed, even when the request failed.
-		 *
-		 * Analytics is non-essential, and returning false here is expensive: the producer
-		 * puts the batch back on the queue and retries the flush up to 10 times from its
-		 * destructor, once per producer. An unreachable endpoint would then cost up to
-		 * 10 timeouts for each of the events, people and groups producers, at PHP
-		 * shutdown, while the visitor is still waiting for the response.
-		 *
-		 * Dropping the batch keeps a degraded endpoint bounded to a single timeout.
-		 * Failures are still reported through _handleError().
+		 * Report the batch as consumed even on failure. Returning false would make the
+		 * producer re-queue it and retry the flush up to 10 times at shutdown, once per
+		 * producer, multiplying the cost of an unreachable endpoint.
 		 *
 		 * @see \WPMedia_Producers_MixpanelBaseProducer::__destruct()
 		 */

--- a/tests/Fixtures/WPConsumer/PersistTest.php
+++ b/tests/Fixtures/WPConsumer/PersistTest.php
@@ -1,0 +1,116 @@
+<?php
+
+return [
+	'testShouldNotSendRequestWhenBatchIsEmpty'           => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [],
+			'timeout_filter'  => null,
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => false,
+			'timeout'  => 1,
+			'blocking' => false,
+		],
+	],
+	'testShouldSendNonBlockingRequestWithDefaultTimeout' => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => null,
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 1,
+			'blocking' => false,
+		],
+	],
+	'testShouldUseTimeoutFromOptions'                    => [
+		'config'   => [
+			'timeout_option'  => 3,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => null,
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 3,
+			'blocking' => false,
+		],
+	],
+	'testShouldUseTimeoutFromFilter'                     => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => 2,
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 2,
+			'blocking' => false,
+		],
+	],
+	'testShouldCastNumericStringTimeoutFromFilter'       => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => '2.5',
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 2.5,
+			'blocking' => false,
+		],
+	],
+	'testShouldFallBackToDefaultTimeoutWhenFilterValueIsInvalid' => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => 'not a number',
+			'blocking_filter' => null,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 1,
+			'blocking' => false,
+		],
+	],
+	'testShouldUseBlockingFromFilter'                    => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => null,
+			'blocking_filter' => true,
+			'is_error'        => false,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 1,
+			'blocking' => true,
+		],
+	],
+	'testShouldReturnTrueWhenRequestFails'               => [
+		'config'   => [
+			'timeout_option'  => null,
+			'batch'           => [ [ 'event' => 'Test' ] ],
+			'timeout_filter'  => null,
+			'blocking_filter' => null,
+			'is_error'        => true,
+		],
+		'expected' => [
+			'sent'     => true,
+			'timeout'  => 1,
+			'blocking' => false,
+		],
+	],
+];

--- a/tests/Fixtures/WPConsumer/PersistTest.php
+++ b/tests/Fixtures/WPConsumer/PersistTest.php
@@ -1,116 +1,31 @@
 <?php
 
 return [
-	'testShouldNotSendRequestWhenBatchIsEmpty'           => [
+	'testShouldNotSendRequestWhenBatchIsEmpty'    => [
 		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [],
-			'timeout_filter'  => null,
-			'blocking_filter' => null,
-			'is_error'        => false,
+			'batch'    => [],
+			'is_error' => false,
 		],
 		'expected' => [
-			'sent'     => false,
-			'timeout'  => 1,
-			'blocking' => false,
+			'sent' => false,
 		],
 	],
-	'testShouldSendNonBlockingRequestWithDefaultTimeout' => [
+	'testShouldSendNonBlockingRequestWithTimeout' => [
 		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => null,
-			'blocking_filter' => null,
-			'is_error'        => false,
+			'batch'    => [ [ 'event' => 'Test' ] ],
+			'is_error' => false,
 		],
 		'expected' => [
-			'sent'     => true,
-			'timeout'  => 1,
-			'blocking' => false,
+			'sent' => true,
 		],
 	],
-	'testShouldUseTimeoutFromOptions'                    => [
+	'testShouldReturnTrueWhenRequestFails'        => [
 		'config'   => [
-			'timeout_option'  => 3,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => null,
-			'blocking_filter' => null,
-			'is_error'        => false,
+			'batch'    => [ [ 'event' => 'Test' ] ],
+			'is_error' => true,
 		],
 		'expected' => [
-			'sent'     => true,
-			'timeout'  => 3,
-			'blocking' => false,
-		],
-	],
-	'testShouldUseTimeoutFromFilter'                     => [
-		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => 2,
-			'blocking_filter' => null,
-			'is_error'        => false,
-		],
-		'expected' => [
-			'sent'     => true,
-			'timeout'  => 2,
-			'blocking' => false,
-		],
-	],
-	'testShouldCastNumericStringTimeoutFromFilter'       => [
-		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => '2.5',
-			'blocking_filter' => null,
-			'is_error'        => false,
-		],
-		'expected' => [
-			'sent'     => true,
-			'timeout'  => 2.5,
-			'blocking' => false,
-		],
-	],
-	'testShouldFallBackToDefaultTimeoutWhenFilterValueIsInvalid' => [
-		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => 'not a number',
-			'blocking_filter' => null,
-			'is_error'        => false,
-		],
-		'expected' => [
-			'sent'     => true,
-			'timeout'  => 1,
-			'blocking' => false,
-		],
-	],
-	'testShouldUseBlockingFromFilter'                    => [
-		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => null,
-			'blocking_filter' => true,
-			'is_error'        => false,
-		],
-		'expected' => [
-			'sent'     => true,
-			'timeout'  => 1,
-			'blocking' => true,
-		],
-	],
-	'testShouldReturnTrueWhenRequestFails'               => [
-		'config'   => [
-			'timeout_option'  => null,
-			'batch'           => [ [ 'event' => 'Test' ] ],
-			'timeout_filter'  => null,
-			'blocking_filter' => null,
-			'is_error'        => true,
-		],
-		'expected' => [
-			'sent'     => true,
-			'timeout'  => 1,
-			'blocking' => false,
+			'sent' => true,
 		],
 	],
 ];

--- a/tests/Unit/WPConsumer/PersistTest.php
+++ b/tests/Unit/WPConsumer/PersistTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace WPMedia\Mixpanel\Tests\Unit\WPConsumer;
+
+use Brain\Monkey\{Filters, Functions};
+use Mockery;
+use Mockery\MockInterface;
+use WPMedia\Mixpanel\Tests\Unit\TestCase;
+use WPMedia\Mixpanel\WPConsumer;
+
+/**
+ * Test the persist method of the WPConsumer class.
+ *
+ * @covers WPMedia\Mixpanel\WPConsumer::persist
+ *
+ * @group WPConsumer
+ */
+class PersistTest extends TestCase {
+	/**
+	 * Host used for the requests under test.
+	 *
+	 * @var string
+	 */
+	private const HOST = 'tracking.example.org';
+
+	/**
+	 * Endpoint used for the requests under test.
+	 *
+	 * @var string
+	 */
+	private const ENDPOINT = '/track';
+
+	/**
+	 * Test the persist method of the WPConsumer class.
+	 *
+	 * @dataProvider configTestData
+	 *
+	 * @param array{timeout_option: int|float|null, batch: mixed[], timeout_filter: mixed, blocking_filter: bool|null, is_error: bool} $config Configuration for the test.
+	 * @param array{sent: bool, timeout: int|float, blocking: bool}                                                                    $expected Expected values for the test.
+	 *
+	 * @return void
+	 */
+	public function testShouldDoExpected( $config, $expected ) {
+		$options = [
+			'host'     => self::HOST,
+			'endpoint' => self::ENDPOINT,
+			'use_ssl'  => true,
+		];
+
+		if ( null !== $config['timeout_option'] ) {
+			$options['timeout'] = $config['timeout_option'];
+		}
+
+		$consumer = new WPConsumer( $options );
+
+		if ( ! $expected['sent'] ) {
+			Filters\expectApplied( 'wp_media_mixpanel_request_timeout' )->never();
+			Filters\expectApplied( 'wp_media_mixpanel_request_blocking' )->never();
+			Functions\expect( 'wp_remote_post' )->never();
+
+			$this->assertTrue( $consumer->persist( $config['batch'] ) );
+
+			return;
+		}
+
+		$default_timeout = null !== $config['timeout_option'] ? $config['timeout_option'] : WPConsumer::DEFAULT_TIMEOUT;
+
+		Filters\expectApplied( 'wp_media_mixpanel_request_timeout' )
+			->once()
+			->with( $default_timeout, self::HOST )
+			->andReturn( null !== $config['timeout_filter'] ? $config['timeout_filter'] : $default_timeout );
+
+		Filters\expectApplied( 'wp_media_mixpanel_request_blocking' )
+			->once()
+			->with( false, self::HOST )
+			->andReturn( null !== $config['blocking_filter'] ? $config['blocking_filter'] : false );
+
+		Functions\expect( 'is_wp_error' )
+			->once()
+			->andReturn( $config['is_error'] );
+
+		Functions\expect( 'wp_remote_post' )
+			->once()
+			->with(
+				'https://' . self::HOST . self::ENDPOINT,
+				[
+					'timeout'  => $expected['timeout'],
+					'blocking' => $expected['blocking'],
+					// Mirrors AbstractConsumer::_encode(), which base64-encodes the JSON payload.
+					'body'     => 'data=' . base64_encode( (string) json_encode( $config['batch'] ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				]
+			)
+			->andReturn( $config['is_error'] ? $this->createErrorResponse() : [ 'response' => [ 'code' => false ] ] );
+
+		// A failed request must still report the batch as consumed, otherwise the producer
+		// re-queues it and retries the flush up to 10 times at shutdown, once per producer.
+		$this->assertTrue( $consumer->persist( $config['batch'] ) );
+	}
+
+	/**
+	 * Create a WP_Error test double.
+	 *
+	 * @return MockInterface
+	 */
+	private function createErrorResponse(): MockInterface {
+		$error = Mockery::mock( 'WP_Error' );
+
+		$error->shouldReceive( 'get_error_code' )
+			->once()
+			->andReturn( 'http_request_failed' );
+
+		$error->shouldReceive( 'get_error_message' )
+			->once()
+			->andReturn( 'Operation timed out' );
+
+		return $error;
+	}
+}

--- a/tests/Unit/WPConsumer/PersistTest.php
+++ b/tests/Unit/WPConsumer/PersistTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace WPMedia\Mixpanel\Tests\Unit\WPConsumer;
 
-use Brain\Monkey\{Filters, Functions};
+use Brain\Monkey\Functions;
 use Mockery;
 use Mockery\MockInterface;
 use WPMedia\Mixpanel\Tests\Unit\TestCase;
@@ -36,27 +36,21 @@ class PersistTest extends TestCase {
 	 *
 	 * @dataProvider configTestData
 	 *
-	 * @param array{timeout_option: int|float|null, batch: mixed[], timeout_filter: mixed, blocking_filter: bool|null, is_error: bool} $config Configuration for the test.
-	 * @param array{sent: bool, timeout: int|float, blocking: bool}                                                                    $expected Expected values for the test.
+	 * @param array{batch: mixed[], is_error: bool} $config Configuration for the test.
+	 * @param array{sent: bool}                     $expected Expected values for the test.
 	 *
 	 * @return void
 	 */
 	public function testShouldDoExpected( $config, $expected ) {
-		$options = [
-			'host'     => self::HOST,
-			'endpoint' => self::ENDPOINT,
-			'use_ssl'  => true,
-		];
-
-		if ( null !== $config['timeout_option'] ) {
-			$options['timeout'] = $config['timeout_option'];
-		}
-
-		$consumer = new WPConsumer( $options );
+		$consumer = new WPConsumer(
+			[
+				'host'     => self::HOST,
+				'endpoint' => self::ENDPOINT,
+				'use_ssl'  => true,
+			]
+		);
 
 		if ( ! $expected['sent'] ) {
-			Filters\expectApplied( 'wp_media_mixpanel_request_timeout' )->never();
-			Filters\expectApplied( 'wp_media_mixpanel_request_blocking' )->never();
 			Functions\expect( 'wp_remote_post' )->never();
 
 			$this->assertTrue( $consumer->persist( $config['batch'] ) );
@@ -64,29 +58,19 @@ class PersistTest extends TestCase {
 			return;
 		}
 
-		$default_timeout = null !== $config['timeout_option'] ? $config['timeout_option'] : WPConsumer::DEFAULT_TIMEOUT;
-
-		Filters\expectApplied( 'wp_media_mixpanel_request_timeout' )
-			->once()
-			->with( $default_timeout, self::HOST )
-			->andReturn( null !== $config['timeout_filter'] ? $config['timeout_filter'] : $default_timeout );
-
-		Filters\expectApplied( 'wp_media_mixpanel_request_blocking' )
-			->once()
-			->with( false, self::HOST )
-			->andReturn( null !== $config['blocking_filter'] ? $config['blocking_filter'] : false );
-
 		Functions\expect( 'is_wp_error' )
 			->once()
 			->andReturn( $config['is_error'] );
 
+		// The timeout and blocking values are fixed: analytics must never delay a
+		// response, so they are neither filterable nor configurable.
 		Functions\expect( 'wp_remote_post' )
 			->once()
 			->with(
 				'https://' . self::HOST . self::ENDPOINT,
 				[
-					'timeout'  => $expected['timeout'],
-					'blocking' => $expected['blocking'],
+					'timeout'  => WPConsumer::REQUEST_TIMEOUT,
+					'blocking' => false,
 					// Mirrors AbstractConsumer::_encode(), which base64-encodes the JSON payload.
 					'body'     => 'data=' . base64_encode( (string) json_encode( $config['batch'] ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				]

--- a/tests/Unit/WPConsumer/PersistTest.php
+++ b/tests/Unit/WPConsumer/PersistTest.php
@@ -62,8 +62,7 @@ class PersistTest extends TestCase {
 			->once()
 			->andReturn( $config['is_error'] );
 
-		// The timeout and blocking values are fixed: analytics must never delay a
-		// response, so they are neither filterable nor configurable.
+		// The timeout and blocking values are fixed, neither filterable nor configurable.
 		Functions\expect( 'wp_remote_post' )
 			->once()
 			->with(
@@ -71,14 +70,14 @@ class PersistTest extends TestCase {
 				[
 					'timeout'  => WPConsumer::REQUEST_TIMEOUT,
 					'blocking' => false,
-					// Mirrors AbstractConsumer::_encode(), which base64-encodes the JSON payload.
+					// Mirrors AbstractConsumer::_encode().
 					'body'     => 'data=' . base64_encode( (string) json_encode( $config['batch'] ) ), // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode, WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 				]
 			)
 			->andReturn( $config['is_error'] ? $this->createErrorResponse() : [ 'response' => [ 'code' => false ] ] );
 
-		// A failed request must still report the batch as consumed, otherwise the producer
-		// re-queues it and retries the flush up to 10 times at shutdown, once per producer.
+		// A failed request must still report the batch as consumed, or the producer
+		// re-queues it and retries the flush up to 10 times at shutdown.
 		$this->assertTrue( $consumer->persist( $config['batch'] ) );
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This description and the changes it covers were AI-generated, and reviewed by the PR author.

# Description

Fixes #33

Analytics batches were sent with a blocking `wp_remote_post()` and no explicit timeout, so a slow or failing tracking proxy delayed PHP execution for the caller. `$this->timeout` defaulted to `30` and `Tracking` never passed one. Reported downstream in WP Rocket 3.23.1: TTFB on uncached page loads went from ~0.6s to ~16.5s while the proxy returned 502/504 after 4–16s.

The request is now non-blocking with a fixed 1 second timeout, and a failed batch is reported as consumed so it is not retried.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated, 3 new unit test cases in `tests/Unit/WPConsumer/PersistTest.php`:

- an empty batch returns `true` without issuing a request;
- a non-empty batch is sent with `'blocking' => false` and `'timeout' => 1`, asserted on the exact `wp_remote_post()` arguments;
- `persist()` returns `true` when `wp_remote_post()` returns a `WP_Error`.

The tests were checked against the old behaviour, not just for passing. Reverting `persist()` to the original blocking 30s + `return false` fails 2 of the 3 cases; the empty-batch case correctly keeps passing in both.

`phpunit` 6 tests / 14 assertions pass, `phpcs` clean, `phpstan` level 9 clean locally.

CI note: the `phpstan` check fails on this branch with 2 errors in `tests/Unit/TestCase.php:58` and `tests/Integration/TestCase.php:58` ("Sealed array shape can only accept a constant array"). Both files are untouched here, and the `develop` run from 2026-05-29 fails with the same two errors and nothing else — CI resolves a newer phpstan than the pinned `vendor/`. This branch adds no phpstan errors, but the check cannot go green until that base-branch breakage is fixed separately.

No live degraded-endpoint measurement was performed — see Unticked items justification.

### How to test

1. Install a plugin using this library with analytics enabled, on a site where page caching can be bypassed.
2. Make the tracking proxy slow or unreachable, e.g. blackhole its IP: `sudo ip route add blackhole <proxy-ip>`.
3. Request an uncached URL that triggers a tracked event and time it: `curl -o /dev/null -s -w '%{time_total}\n' 'https://example.com/?nocache=1'`.
4. TTFB should increase by at most ~1s. Before this change it increased by the endpoint's full time-to-failure, up to the timeout multiplied by the destructor's retries.

To observe the request itself, add a mu-plugin hooking `http_api_debug` and log `$parsed_args['blocking']` and `$parsed_args['timeout']` for requests to the proxy host.

### Affected Features & Quality Assurance Scope

Every Mixpanel event sent through this library, in all consuming plugins — event tracking, `identify()`, and `set_user_property()`. The change is in the single HTTP call all of them funnel through (`WPConsumer::persist()`).

QA scope: confirm events still arrive in the Mixpanel project under normal conditions (this is the main regression risk — see Risks), and that a degraded proxy no longer affects page generation time.

## Technical description

### Documentation

`WPConsumer::persist()` now passes `'timeout' => self::REQUEST_TIMEOUT` (1) and `'blocking' => false` to `wp_remote_post()`, and always returns `true`. Neither value is filterable or configurable: the `timeout` and `blocking` keys are no longer read from the options array, and the constructor's parameter shape no longer accepts them.

Returning `true` on failure is the load-bearing part. `WPMedia_Producers_MixpanelBaseProducer::__destruct()` re-queues a failed batch and retries the flush up to **10 times**, and `WPMedia_Mixpanel` builds three producers — events, people and groups — each with its own consumer and destructor. `persist()` returning `false` on a `WP_Error` therefore cost up to `timeout × 10 × 3` at PHP shutdown, while the visitor was still waiting. Dropping the batch instead bounds a degraded endpoint to a single timeout, and needs no changes to the vendored `src/Classes/` fork.

Two details that are easy to get wrong, both documented in the code and the README:

- **1 second is a floor, not a choice.** `wp-includes/Requests/src/Transport/Curl.php:431` clamps the cURL timeout to a minimum of 1 second, because cURL's system DNS resolver uses `alarm()`, which only has second resolution. `0.01` and `1` produce identical cURL options — this is what the WP core cron docblock means by "A timeout of `0.01` may end up taking 1 second".
- **`'blocking' => false` is not fire-and-forget.** In the same transport, `CURLOPT_TIMEOUT` is set unconditionally (line 434) and `curl_exec()` (line 205) still performs the full request/response cycle; `blocking === false` only skips the header/write callbacks and discards the body. A non-blocking request that times out still returns a `WP_Error`. The timeout is what bounds the cost.

### New dependencies

None.

### Risks

- **Event loss on slow connections.** `Tracking` passes no timeout, so 1s now applies to every consumer of this library on upgrade, with no opt-out. A downstream that was relying on the 30s timeout to deliver events over a slow link will start losing them. This is the intended trade of #33 — analytics must not delay a response — but it is the main thing to weigh before merging.
- **Failures are silent.** A dropped batch is only reported through `_handleError()`, which routes to the consumer's `error_callback` or the debug log. There is no counter or admin-visible signal. #34 adds circuit-breaker state that makes degradation observable.
- **Subclass compatibility.** The `protected $timeout` property was removed. Any subclass of `WPConsumer` referencing it would break; none exists in this repo.
- Performance: strictly improves. Worst case per request goes from `30s × 10 × 3` to one 1s timeout.
- Security: unchanged. `sslverify` is untouched and still defaults to on.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

**Acceptance Criteria.** The code-level criteria are covered by unit tests, but the last one — "worst-case added wall time for a fully unreachable endpoint is ~1s, not ~30s+" — was argued from the transport source rather than measured against a live degraded endpoint. The reasoning is in the Technical description; a validator following How to test can confirm it empirically.

**Output messages.** Deliberately not addressed. A failed analytics batch is dropped and surfaces only via the existing `_handleError()` path, because there is no useful action for a site owner to take about a telemetry POST that did not land. Making degradation observable belongs with the circuit breaker in #34, which has state worth reporting.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Observability was not added, for the reason given above. Follow-ups that prevent this recurring in another form: #34 (circuit breaker) and #35 (keep analytics off the front-end render path, and gate `identify()` / `set_user_property()` by capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
