### PR TITLE
Update Mixpanel hostname to api-eu.mixpanel.com (v1.4.3)

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -6,7 +6,7 @@ namespace WPMedia\Mixpanel;
 use WPMedia_Mixpanel;
 
 class Tracking {
-	const HOST = 'mixpanel-proxy.group.one';
+	const HOST = 'api-eu.mixpanel.com';
 
 	/**
 	 * Mixpanel instance


### PR DESCRIPTION
## Summary
- The `mixpanel-proxy.group.one` hostname is being retired; send tracking requests directly to Mixpanel's EU API endpoint (`api-eu.mixpanel.com`) instead.
- No other version references exist in this repo (no `Version:` header, no version field in `composer.json`) — releases are tracked purely via git tags, so tagging `v1.4.3` after merge is sufficient to release.

## Test plan
- [ ] Confirm tracking requests successfully reach `api-eu.mixpanel.com` in a staging environment
- [ ] Tag `v1.4.3` on develop after merge to release