### PR TITLE
Fix Mixpanel JS library URL returning access denied

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -8,6 +8,8 @@ use WPMedia_Mixpanel;
 class Tracking {
 	const HOST = 'api-eu.mixpanel.com';
 
+	const LIB_URL = 'https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js';
+
 	/**
 	 * Mixpanel instance
 	 *
@@ -207,7 +209,7 @@ class Tracking {
 	public function add_script(): void {
 		?>
 		<!-- start Mixpanel --><script>
-		const MIXPANEL_CUSTOM_LIB_URL = "https://<?php echo esc_js( self::HOST ); ?>/lib.min.js";
+		const MIXPANEL_CUSTOM_LIB_URL = "<?php echo esc_js( self::LIB_URL ); ?>";
 		(function (f, b) { if (!b.__SV) { var e, g, i, h; window.mixpanel = b; b._i = []; b.init = function (e, f, c) { function g(a, d) { var b = d.split("."); 2 == b.length && ((a = a[b[0]]), (d = b[1])); a[d] = function () { a.push([d].concat(Array.prototype.slice.call(arguments, 0))); }; } var a = b; "undefined" !== typeof c ? (a = b[c] = []) : (c = "mixpanel"); a.people = a.people || []; a.toString = function (a) { var d = "mixpanel"; "mixpanel" !== c && (d += "." + c); a || (d += " (stub)"); return d; }; a.people.toString = function () { return a.toString(1) + ".people (stub)"; }; i = "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split( " "); for (h = 0; h < i.length; h++) g(a, i[h]); var j = "set set_once union unset remove delete".split(" "); a.get_group = function () { function b(c) { d[c] = function () { call2_args = arguments; call2 = [c].concat(Array.prototype.slice.call(call2_args, 0)); a.push([e, call2]); }; } for ( var d = {}, e = ["get_group"].concat( Array.prototype.slice.call(arguments, 0)), c = 0; c < j.length; c++) b(j[c]); return d; }; b._i.push([e, f, c]); }; b.__SV = 1.2; e = f.createElement("script"); e.type = "text/javascript"; e.async = !0; e.src = "undefined" !== typeof MIXPANEL_CUSTOM_LIB_URL ? MIXPANEL_CUSTOM_LIB_URL : "file:" === f.location.protocol && "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//) ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js" : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"; g = f.getElementsByTagName("script")[0]; g.parentNode.insertBefore(e, g); } })(document, window.mixpanel || []);
 		mixpanel.init( '<?php echo esc_js( $this->token ); ?>', {
 			api_host: "https://<?php echo esc_js( self::HOST ); ?>",


### PR DESCRIPTION
## Summary
- The Mixpanel JS SDK (`lib.min.js`) was being loaded from `https://api-eu.mixpanel.com/lib.min.js`, but `api-eu.mixpanel.com` is the EU regional **API ingestion endpoint** used for tracking/identify requests — it does not serve static assets, so the request returned "access denied" and the library failed to load.
- Added a dedicated `Tracking::LIB_URL` constant pointing at Mixpanel's actual CDN (`https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js`) and used it for `MIXPANEL_CUSTOM_LIB_URL` instead of deriving it from `self::HOST`.
- `api_host` still correctly uses `self::HOST` (`api-eu.mixpanel.com`) for EU-region tracking requests — that part was unaffected and unchanged.

## Why
`HOST` is meant for the tracking API endpoint, not for hosting static JS. Deriving the library URL from it was the root cause of the "access denied" error reported when loading `https://api-eu.mixpanel.com/lib.min.js` directly.

## Test plan
- [ ] Load a page with the Mixpanel snippet and confirm `lib.min.js` loads successfully from `cdn.mxpnl.com` (200, not access denied)
- [ ] Confirm Mixpanel events still hit `api-eu.mixpanel.com` (check Network tab for `/track/` requests)
- [ ] Confirm events appear in the Mixpanel EU project dashboard