### PR TITLE
Fix PHPStan CI errors in TestCase base classes

### DIFF
--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Configuration for the test data.
 	 *
-	 * @var array{'test_data'?: array<string, mixed>}
+	 * @var array<string, mixed>
 	 */
 	protected $config;
 
@@ -37,9 +37,9 @@ abstract class TestCase extends BaseTestCase {
 			$this->loadTestDataConfig();
 		}
 
-		return isset( $this->config['test_data'] )
-			? $this->config['test_data']
-			: $this->config;
+		$test_data = $this->config['test_data'] ?? $this->config;
+
+		return is_array( $test_data ) ? $test_data : [];
 	}
 
 	/**

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Configuration for the test data.
 	 *
-	 * @var array{'test_data'?: array<string, mixed>}
+	 * @var array<string, mixed>
 	 */
 	protected $config;
 
@@ -37,9 +37,9 @@ abstract class TestCase extends BaseTestCase {
 			$this->loadTestDataConfig();
 		}
 
-		return isset( $this->config['test_data'] )
-			? $this->config['test_data']
-			: $this->config;
+		$test_data = $this->config['test_data'] ?? $this->config;
+
+		return is_array( $test_data ) ? $test_data : [];
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `composer phpstan` (level 9) was failing with `assign.propertyType` errors in both `tests/Unit/TestCase.php` and `tests/Integration/TestCase.php`:
  > `Property ...::$config (array{test_data?: array<string, mixed>}) does not accept array.`
  > Sealed array shape can only accept a constant array. Extra keys are not allowed.
- Root cause: `$config` was typed as a sealed array shape, but it's assigned the return value of `getTestData()` (a plain, dynamically-built `array`) in `loadTestDataConfig()`. PHPStan sealed shapes only accept literal/constant arrays, never a dynamically assigned one, so any real assignment fails.
- Fix: relaxed `$config`'s type to `array<string, mixed>`, and in `configTestData()` narrowed the `'test_data'` lookup with `is_array()` so the method can still statically guarantee its `array<string, mixed>` return type.

## Why
The sealed shape was never enforceable given how `$config` is populated at runtime, so it made PHPStan level 9 fail without catching any real bug. The fix keeps accurate typing without loosening `configTestData()`'s guarantees.

## Test plan
- [x] `composer phpstan` passes with no errors
- [x] `composer test-unit` passes (6 tests, 14 assertions)
- [ ] `composer test-integration` passes in CI